### PR TITLE
ci: drop broken REPO_TOKEN + grant contents:write

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v5
     - name: Setup .NET
@@ -47,5 +49,4 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: ${{ steps.build_artifact.outputs.ARTIFACT_PATH }}
-        token: ${{ secrets.REPO_TOKEN }}
         


### PR DESCRIPTION
The release asset upload failed on tag 4.1.0 with 'Bad credentials' because REPO_TOKEN is stale. Drop the explicit token and rely on the default GITHUB_TOKEN with contents:write scope. Same pattern as NosCore.Packets and NosCore.Shared PRs.